### PR TITLE
chore: fmtok8s-api-gateway to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.118
+- name: fmtok8s-api-gateway
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.2
 - name: fmtok8s-monolith
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.1


### PR DESCRIPTION
chore: Promote fmtok8s-api-gateway to version 0.0.2