### PR TITLE
chore: fmtok8s-api-gateway to 0.0.36

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.13
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.35
+  version: 0.0.36
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.27


### PR DESCRIPTION
chore: Promote fmtok8s-api-gateway to version 0.0.36